### PR TITLE
Add .gitignore to exclude Finder-generated .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
<img width="372" alt="Screenshot 2025-07-07 at 9 34 34 PM" src="https://github.com/user-attachments/assets/4d0e949e-a181-48fd-8d7a-e1404e38fba6" />

Finder generates a .DS_Store file for each and every folder you browse. Adding it to .gitignore to make the repo easier to work on (you don’t have to find what you actually want to commit among the disturbance). Prevents someone from accidentally commiting the .DS_Store file. 