### PR TITLE
mayjunejuly/arc-broswer-companion: Update README

### DIFF
--- a/workflows/mayjunejuly/arc-browser-companion/readme.md
+++ b/workflows/mayjunejuly/arc-browser-companion/readme.md
@@ -1,8 +1,10 @@
 ## Usage
 
-Search Arc browser tabs and spaces via the `arctabs` keyword. Press <kbd>↩</kbd> to switch to it.
+Search Arc browser tabs and Spaces via the `arctabs` keyword. Press <kbd>↩</kbd> to switch to it.
 
 ![Searching Arc browser tabs](images/keyword_search.png)
+
+Configure the Hotkey for faster triggering.
 
 Back up your tabs to an HTML file with the `backuparc` keyword. Set up where the file is saved to in the Workflow’s Configuration.
 

--- a/workflows/mayjunejuly/arc-browser-companion/readme.md
+++ b/workflows/mayjunejuly/arc-browser-companion/readme.md
@@ -1,8 +1,14 @@
 ## Usage
 
-Search Arc browser tabs and Spaces via the `arctabs` keyword. Press <kbd>↩</kbd> to switch to it.
+Search Arc browser tabs and Spaces via the `arctabs` keyword.
 
 ![Searching Arc browser tabs](images/keyword_search.png)
+
+* <kbd>↩</kbd> Switch to the tab or Space.
+* <kbd>⌘</kbd><kbd>↩</kbd> Flush cache if enabled.
+* <kbd>⌃</kbd><kbd>↩</kbd> Copy tab’s URL.
+* <kbd>⇧</kbd><kbd>↩</kbd> Copy tab’s name.
+* <kbd>⌥</kbd><kbd>↩</kbd> Close tab.
 
 Configure the Hotkey for faster triggering.
 


### PR DESCRIPTION
- ‘Space’ is a terminology of Arc, thus should be capitalized. 
- Mention the hotkey trigger for searching Spaces and tabs.
- Added descripions for modifier keys for the search action. 