### PR TITLE
Fix formatting in README for hide/show windows instructions

### DIFF
--- a/workflows/vanstrouble/hide-show-windows/readme.md
+++ b/workflows/vanstrouble/hide-show-windows/readme.md
@@ -4,12 +4,12 @@ Hide windows via the `hideall` keyword.
 
 ![Hide windows](images/hideall.png)
 
-<kbd>↩</kbd> Hide all windows except the frontmost.
-<kbd>⌘</kbd><kbd>↩</kbd> Hide all windows and collaps Finder windows.
+* <kbd>↩</kbd> Hide all windows except the frontmost.
+* <kbd>⌘</kbd><kbd>↩</kbd> Hide all windows and collaps Finder windows.
 
 Show windows via the `showall` keyword.
 
 ![Show windows](images/showall.png)
 
-<kbd>↩</kbd> Show hidden windows.
-<kbd>⌘</kbd><kbd>↩</kbd> Show hidden windows and collapsed Finder windows.
+* <kbd>↩</kbd> Show hidden windows.
+* <kbd>⌘</kbd><kbd>↩</kbd> Show hidden windows and collapsed Finder windows.


### PR DESCRIPTION
The list was missing from the workflow documentation. Also, if you can fix the problem with the keyword `hideall`, which still appears as `hide` in the [Alfred Gallery](https://alfred.app/workflows/vanstrouble/hide-show-windows/).